### PR TITLE
Added support for 2026.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [2.0.7] - 2026-03-31
+
+- added support for 2026.1
+
 ## [2.0.3] - 2025-05-08
 
 - added support for 2025.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,17 +5,17 @@ pluginGroup = com.github.coeiico
 #pluginName = "Nightfall Theme"
 pluginRepositoryUrl = https://github.com/coeiico/jetbrains-nightfall-theme
 # SemVer format -> https://semver.org
-pluginVersion = 2.0.6
+pluginVersion = 2.0.7
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223
-pluginUntilBuild = 253.*
+pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 # platformType = IU
 # platformVersion = LATEST-EAP-SNAPSHOT
 platformType = IC
-platformVersion = 253-EAP-SNAPSHOT
+platformVersion = 261-EAP-SNAPSHOT
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
     <id>com.brandiico.jetbrains-nightfall-theme</id>
     <name>Nightfall Theme</name>
     <vendor url="https://github.com/mattlibera">Originally by Brandon Coetzee, now maintained by Matt Libera</vendor>
-    <idea-version since-build="223.0" until-build="252.*"/>
+    <idea-version since-build="223.0" until-build="261.*"/>
 
     <depends>com.intellij.modules.platform</depends>
 


### PR DESCRIPTION
## Summary

- Bumped `pluginVersion` to `2.0.7`
- Updated `pluginUntilBuild` and `platformVersion` to `261.*` / `261-EAP-SNAPSHOT` for JetBrains 2026.1
- Updated `until-build` in `plugin.xml` to `261.*`
- Added changelog entry for `2.0.7`

## Test plan

- [ ] Verify plugin loads correctly in a 2026.1 IDE build
- [ ] Confirm theme applies without errors