### PR TITLE
Remove upper IDE version bound (untilBuild)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ tasks {
     patchPluginXml {
         version = properties("pluginVersion")
         sinceBuild = properties("pluginSinceBuild")
-        untilBuild = properties("pluginUntilBuild")
+        untilBuild = provider { null }
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginVersion = 2.0.6
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223
-pluginUntilBuild = 253.*
+pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 # platformType = IU

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
     <id>com.brandiico.jetbrains-nightfall-theme</id>
     <name>Nightfall Theme</name>
     <vendor url="https://github.com/mattlibera">Originally by Brandon Coetzee, now maintained by Matt Libera</vendor>
-    <idea-version since-build="223.0" until-build="252.*"/>
+    <idea-version since-build="223.0"/>
 
     <depends>com.intellij.modules.platform</depends>
 


### PR DESCRIPTION
## Summary
- Set `untilBuild` to `provider { null }` so no upper version constraint is written to the plugin descriptor
- Clear `pluginUntilBuild` in `gradle.properties`
- Remove `until-build` attribute from `plugin.xml`

The plugin will be compatible with all future IntelliJ platform versions (2026.1+) without requiring a new release for each IDE version.