### PR TITLE
Fix Kover 0.9.8 DSL migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,10 +60,12 @@ qodana {
 }
 
 // Configure Gradle Kover Plugin - read more: https://github.com/Kotlin/kotlinx-kover#configuration
-koverReport {
-    defaults {
-        xml {
-            onCheck = true
+kover {
+    reports {
+        total {
+            xml {
+                onCheck = true
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ kotlin = "2.3.21"
 changelog = "2.5.0"
 gradleIntelliJPlugin = "1.17.4"
 qodana = "0.1.13"
-kover = "0.7.3"
+kover = "0.9.8"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }


### PR DESCRIPTION
## Summary

- Bumps `org.jetbrains.kotlinx.kover` from 0.7.3 to 0.9.8 (originally from dependabot #74)
- Migrates `koverReport { defaults { ... } }` to `kover { reports { total { ... } } }` — the old DSL was removed in Kover 0.8.0

## Test plan

- [x] `./gradlew check` passes locally with the new DSL
- [x] Kover tasks (`koverGenerateArtifact`, `koverXmlReport`, `koverVerify`) all ran successfully

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)